### PR TITLE
Web shift enter for newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.5
+
+- Enable web to enter newline when pressing SHIFT + ENTER.
+
 # 0.9.4
 
 - Update llmQuizView questionId mapping

--- a/lib/src/views/chat_input/text_or_audio_input.dart
+++ b/lib/src/views/chat_input/text_or_audio_input.dart
@@ -3,7 +3,6 @@ import 'package:flutter/widgets.dart';
 import 'package:waveform_recorder/waveform_recorder.dart';
 
 import '../../styles/styles.dart';
-import '../../utility.dart';
 import '../chat_text_field.dart';
 import 'editing_indicator.dart';
 import 'input_state.dart';

--- a/lib/src/views/chat_input/text_or_audio_input.dart
+++ b/lib/src/views/chat_input/text_or_audio_input.dart
@@ -91,10 +91,7 @@ class TextOrAudioInput extends StatelessWidget {
                       controller: _textController,
                       autofocus: _autofocus,
                       focusNode: _focusNode,
-                      textInputAction:
-                          isMobile
-                              ? TextInputAction.newline
-                              : TextInputAction.done,
+                      textInputAction: TextInputAction.newline,
                       onSubmitted:
                           _inputState == InputState.disabled
                               ? null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: flutter_ai_toolkit
 description: >-
   A set of AI chat-related widgets for Flutter apps targeting
   mobile, desktop, and web.
-version: 0.9.4
+version: 0.9.5
 repository: https://github.com/flutter/ai
 
 topics:


### PR DESCRIPTION
This PR makes `ENTER` key of the `TextInputAction` insert newline into the text field.
It then handles the prompt submission through the focus node, which will ignore the `ENTER` key when `SHIFT` is pressed, but it captures the `ENTER` key without the `SHIFT` key.